### PR TITLE
Add SEO, GA and planet page links

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,6 +467,7 @@
             document.getElementById('toggleLabels').addEventListener('click', toggleLabels);
             document.getElementById('resetCamera').addEventListener('click', resetCamera);
             document.getElementById('speedSlider').addEventListener('input', updateSpeed);
+            renderer.domElement.addEventListener('click', onCanvasClick);
 
             // Start animation
             animate();
@@ -653,6 +654,22 @@
                 }
             } else {
                 selectedObject = null;
+            }
+        }
+
+        // Handle click on a planet to open its detail page
+        function onCanvasClick(event) {
+            mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+            mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+
+            raycaster.setFromCamera(mouse, camera);
+            const planetMeshes = planets.map(p => p.mesh);
+            const intersects = raycaster.intersectObjects(planetMeshes);
+            if (intersects.length > 0) {
+                const planetObj = planets.find(p => p.mesh === intersects[0].object);
+                if (planetObj) {
+                    window.location.href = 'planets/' + planetObj.data.name + '.html';
+                }
             }
         }
 

--- a/planets/Earth.html
+++ b/planets/Earth.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Earth</title>
+    <meta name="description" content="Earth is the third planet from the Sun and the only known world to harbor life, with vast oceans and dynamic geology.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Earth.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Earth - Solar System">
+    <meta property="og:description" content="Earth is the third planet from the Sun and the only known world to harbor life, with vast oceans and dynamic geology.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Earth.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Earth - Solar System">
+    <meta name="twitter:description" content="Earth is the third planet from the Sun and the only known world to harbor life, with vast oceans and dynamic geology.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Jupiter.html
+++ b/planets/Jupiter.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Jupiter</title>
+    <meta name="description" content="Jupiter is the largest planet in our Solar System, a gas giant known for its Great Red Spot and strong magnetic field.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Jupiter.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Jupiter - Solar System">
+    <meta property="og:description" content="Jupiter is the largest planet in our Solar System, a gas giant known for its Great Red Spot and strong magnetic field.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Jupiter.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Jupiter - Solar System">
+    <meta name="twitter:description" content="Jupiter is the largest planet in our Solar System, a gas giant known for its Great Red Spot and strong magnetic field.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Mars.html
+++ b/planets/Mars.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Mars</title>
+    <meta name="description" content="Mars, the ‘Red Planet,’ is a cold desert world with the largest volcano and canyon in the Solar System.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Mars.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Mars - Solar System">
+    <meta property="og:description" content="Mars, the ‘Red Planet,’ is a cold desert world with the largest volcano and canyon in the Solar System.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Mars.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Mars - Solar System">
+    <meta name="twitter:description" content="Mars, the ‘Red Planet,’ is a cold desert world with the largest volcano and canyon in the Solar System.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Mercury.html
+++ b/planets/Mercury.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Mercury</title>
+    <meta name="description" content="Mercury is the smallest and innermost planet of the Solar System, notable for its swift 88‑day orbit around the Sun.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Mercury.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Mercury - Solar System">
+    <meta property="og:description" content="Mercury is the smallest and innermost planet of the Solar System, notable for its swift 88‑day orbit around the Sun.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Mercury.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Mercury - Solar System">
+    <meta name="twitter:description" content="Mercury is the smallest and innermost planet of the Solar System, notable for its swift 88‑day orbit around the Sun.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Neptune.html
+++ b/planets/Neptune.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Neptune</title>
+    <meta name="description" content="Neptune, the outermost planet, is an ice giant noted for its deep blue hue and supersonic winds.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Neptune.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Neptune - Solar System">
+    <meta property="og:description" content="Neptune, the outermost planet, is an ice giant noted for its deep blue hue and supersonic winds.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Neptune.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Neptune - Solar System">
+    <meta name="twitter:description" content="Neptune, the outermost planet, is an ice giant noted for its deep blue hue and supersonic winds.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Saturn.html
+++ b/planets/Saturn.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Saturn</title>
+    <meta name="description" content="Saturn is a gas giant distinguished by its prominent ring system composed of ice and rock particles.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Saturn.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Saturn - Solar System">
+    <meta property="og:description" content="Saturn is a gas giant distinguished by its prominent ring system composed of ice and rock particles.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Saturn.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Saturn - Solar System">
+    <meta name="twitter:description" content="Saturn is a gas giant distinguished by its prominent ring system composed of ice and rock particles.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Sun.html
+++ b/planets/Sun.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Sun</title>
+    <meta name="description" content="The Sun is the star at the center of our Solar System and the primary source of energy for life on Earth.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Sun.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Sun - Solar System">
+    <meta property="og:description" content="The Sun is the star at the center of our Solar System and the primary source of energy for life on Earth.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Sun.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Sun - Solar System">
+    <meta name="twitter:description" content="The Sun is the star at the center of our Solar System and the primary source of energy for life on Earth.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Uranus.html
+++ b/planets/Uranus.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Uranus</title>
+    <meta name="description" content="Uranus is an ice giant with a dramatic axial tilt of 98° causing it to ‘roll’ around the Sun.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Uranus.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Uranus - Solar System">
+    <meta property="og:description" content="Uranus is an ice giant with a dramatic axial tilt of 98° causing it to ‘roll’ around the Sun.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Uranus.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Uranus - Solar System">
+    <meta name="twitter:description" content="Uranus is an ice giant with a dramatic axial tilt of 98° causing it to ‘roll’ around the Sun.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }

--- a/planets/Venus.html
+++ b/planets/Venus.html
@@ -4,6 +4,28 @@
 <head>
     <meta charset="utf-8">
     <title>Venus</title>
+    <meta name="description" content="Venus, Earth’s ‘sister planet,’ is shrouded in a dense, toxic atmosphere and rotates retrograde once every 243 Earth days.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://solar-system.lamdalf.com/planets/Venus.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Venus - Solar System">
+    <meta property="og:description" content="Venus, Earth’s ‘sister planet,’ is shrouded in a dense, toxic atmosphere and rotates retrograde once every 243 Earth days.">
+    <meta property="og:url" content="https://solar-system.lamdalf.com/planets/Venus.html">
+    <meta property="og:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Venus - Solar System">
+    <meta name="twitter:description" content="Venus, Earth’s ‘sister planet,’ is shrouded in a dense, toxic atmosphere and rotates retrograde once every 243 Earth days.">
+    <meta name="twitter:image" content="https://solar-system.lamdalf.com/og-image.png">
+    <link rel="icon" href="https://solar-system.lamdalf.com/favicon.ico">
+    <link rel="apple-touch-icon" href="https://solar-system.lamdalf.com/apple-touch-icon.png">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCSCGPLDTC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCSCGPLDTC');
+    </script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         h1 { margin-bottom: 0; }


### PR DESCRIPTION
## Summary
- add Google Analytics and SEO metadata to new planetary pages
- enable clicking planets to open their respective pages from the simulation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863f7d13d30832c907ef3fa03ad84f6